### PR TITLE
fix(auth): implement token auto-refresh and persistence

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,12 +1,15 @@
-# Refine Calorie Rings UI
+# Auth Persistence Improvements
 
-## User Prompts
+## User Prompt
+> There is a problem where auth really doesn't last at all for hte client. I'd like the user to stay logged in as long as possible to avoid ahving to re-authenticate all the time.
 
-### Initial Request
-We recently did a UI overhaul and the app is looking pretty good. A few small issues:
-(1) the calories ring is shown as "Tokens"
-The effects aren't as 'glowy' as they are meant to be for the rings. See the attached screenshot or the mockups in the UI overhaul document. 
-(2) though the mockups show percentages outside the rings, I think we should show percentages as tiny black letters inside the tip of the ring, so that if the ring wraps around we can still read the percentage. It'd be nice to have the icons inside the rings as well, as pictured in the mockup/screenshot.
+## Changes
+- Implemented proactive token refresh in `src/lib/auth.ts`.
+- Added `scheduleRefresh` to refresh token 5 minutes before expiry.
+- Added `visibilitychange` listener to refresh token when tab becomes visible if near expiry.
+- Improved `initializeAuth` to handle session restoration with accurate remaining time.
+- Fixed TS errors in `src/routes/log/+page.svelte`.
 
-### Feedback / Refinement Request
-Not a bad first attempt, but still some refinement is needed. The rings themselves should be fatter. The % text should be rotated so that it is in line with the ring — you might even need to rotate and position each letter individually so that it looks right. The stats should always be inside the macrobubble, not below. The icons for the macrobubbles look bad, maybe get nanobanana to generate small images instead.
+## Artifacts
+- [Implementation Plan](docs/auth_persistence/implementation_plan.md)
+- [Walkthrough](docs/auth_persistence/walkthrough.md)

--- a/docs/auth_persistence/implementation_plan.md
+++ b/docs/auth_persistence/implementation_plan.md
@@ -1,0 +1,45 @@
+# OAuth Token Auto-Refresh Implementation Plan
+
+## Goal Description
+Implement proactive token refreshment to keep the user logged in as long as possible. Currently, the access token expires in 1 hour, forcing the user to re-authenticate. We will add logic to silently refresh the token before it expires using Google Identity Services `requestAccessToken({ prompt: '' })`.
+
+## Proposed Changes
+
+### Auth Library
+#### [MODIFY] [auth.ts](file:///Users/anicolao/projects/antigravity/food-fixups/src/lib/auth.ts)
+- Add a `refreshAuth()` function that calls `tokenClient.requestAccessToken({ prompt: '' })`.
+- Add a `scheduleRefresh(expiresInSeconds)` function.
+    - Clears any existing timeout.
+    - Sets a timeout for `(expiresInSeconds - 300) * 1000` (5 minutes before expiry).
+    - If `expiresInSeconds` is less than 300, refresh immediately (or very soon).
+- Update `initClient` callback:
+    - Call `scheduleRefresh` with the returned `expires_in`.
+- Update `initializeAuth`:
+    - When restoring token, calculate remaining time.
+    - Call `scheduleRefresh` with the remaining time.
+- Update `signOut`:
+    - Clear the refresh timeout.
+- Add `visibilitychange` event listener to check expiry and refresh if needed when the user returns to the tab (recovering from sleep).
+
+## Verification Plan
+
+### Manual Verification
+1.  **Short Expiry Test**:
+    - Temporarily modify `auth.ts` to set `expiresInSeconds` to `60` (1 minute) in `initClient`, and maybe `10` seconds for the refresh buffer.
+    - Log in to the application.
+    - Open the specific devtools (Network tab).
+    - Filter for `oauth2` or requests to Google.
+    - Wait for 1 minute (or the shortened time).
+    - **Expectation**: A new token request is triggered automatically. The local storage `food_log_token_expiry` updates to a new future time.
+    - Reload the page.
+    - **Expectation**: You are still logged in.
+
+2.  **Persistence Test**:
+    - Log in.
+    - Refresh the page.
+    - **Expectation**: You stay logged in (this already works, but verifying regressions).
+
+3.  **Sleep Test** (Optional but recommended):
+    - Close the laptop lid or background the tab for > 1 hour (or the modified short duration).
+    - Wake up / focus tab.
+    - **Expectation**: The `visibilitychange` handler triggers a check, sees it's expired or about to, and triggers a refresh.

--- a/docs/auth_persistence/walkthrough.md
+++ b/docs/auth_persistence/walkthrough.md
@@ -1,0 +1,25 @@
+# Auth Persistence Walkthrough
+
+## Changes Implemented
+
+### [MODIFY] [auth.ts](file:///Users/anicolao/projects/antigravity/food-fixups/src/lib/auth.ts)
+- **Token Auto-Refresh**: Added a `scheduleRefresh` function that sets a timer to refresh the token 5 minutes (300 seconds) before it expires.
+- **Silent Refresh**: Uses `tokenClient.requestAccessToken({ prompt: '' })` to refresh without user interaction.
+- **Visibility Handling**: Added a `visibilitychange` listener to check token validity and refresh if needed when the user returns to the tab (e.g., after waking the device).
+- **Graceful Restoration**: Enhanced `initializeAuth` to calculate remaining time on restored tokens and schedule the refresh accordingly.
+- **Cleanup**: Updated `signOut` to clear any pending refresh timers.
+
+### [MODIFY] [log/+page.svelte](file:///Users/anicolao/projects/antigravity/food-fixups/src/routes/log/+page.svelte)
+- **Fix TS Errors**: Added optional chaining `fileInput?.click()` to resolve TypeScript errors found during verification.
+
+## Verification Results
+
+### Automated Checks
+- **Build Verification**: Ran `npm run check` (svelte-check) which passed with 0 errors.
+
+### Manual Verification Steps (Recommended)
+1.  **Login**: Sign in to the application.
+2.  **Inspect Storage**: Open DevTools > Application > Local Storage. Verify `food_log_access_token` and `food_log_token_expiry` are present.
+3.  **Wait**: Leave the tab open (or modify the `REFRESH_BUFFER_SECONDS` temporarily to test faster).
+4.  **Observe**: Watch the network tab for a new token request or the local storage expiry updating automatically before the session dies.
+5.  **Sleep/Wake**: Put the computer to sleep for a duration longer than the buffer, wake it up, and return to the tab. The app should trigger a refresh immediately.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,20 +20,34 @@ declare const google: any;
 
 let tokenClient: any;
 let accessToken: string | null = null;
+let refreshTimeoutId: any = null;
 
 const TOKEN_KEY = 'food_log_access_token';
 const EXPIRY_KEY = 'food_log_token_expiry';
+const REFRESH_BUFFER_SECONDS = 300; // Refresh 5 minutes before expiry
 
 export function initializeAuth(onSuccess: (token: string) => void) {
     // 1. Try to restore from localStorage first
     const storedToken = localStorage.getItem(TOKEN_KEY);
     const storedExpiry = localStorage.getItem(EXPIRY_KEY);
 
+    // Setup visibility listener to catch expiry when waking from sleep
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') {
+            checkAndRefreshIfNeeded(onSuccess);
+        }
+    });
+
     if (storedToken && storedExpiry) {
-        if (Date.now() < parseInt(storedExpiry)) {
+        const expiryTime = parseInt(storedExpiry);
+        if (Date.now() < expiryTime) {
             accessToken = storedToken;
             onSuccess(accessToken);
             (window as any)._authReady = true;
+
+            // Schedule refresh based on remaining time
+            const remainingSeconds = (expiryTime - Date.now()) / 1000;
+            scheduleRefresh(remainingSeconds, onSuccess);
         } else {
             // Expired
             signOut();
@@ -64,19 +78,72 @@ function initClient(onSuccess: (token: string) => void) {
         scope: SCOPES,
         callback: (response: any) => {
             if (response.access_token) {
-                accessToken = response.access_token as string;
-                const expiresInSeconds = response.expires_in || 3599; // Default to 1h
-                const expiryTime = Date.now() + (expiresInSeconds * 1000);
-
-                localStorage.setItem(TOKEN_KEY, accessToken);
-                localStorage.setItem(EXPIRY_KEY, expiryTime.toString());
-
-                onSuccess(accessToken);
+                handleTokenResponse(response, onSuccess);
             }
         },
     });
     // Signal tests that client is initialized
     (window as any)._authReady = true;
+}
+
+function handleTokenResponse(response: any, onSuccess: (token: string) => void) {
+    accessToken = response.access_token as string;
+    const expiresInSeconds = response.expires_in || 3599; // Default to 1h
+    const expiryTime = Date.now() + (expiresInSeconds * 1000);
+
+    localStorage.setItem(TOKEN_KEY, accessToken);
+    localStorage.setItem(EXPIRY_KEY, expiryTime.toString());
+
+    onSuccess(accessToken);
+    scheduleRefresh(expiresInSeconds, onSuccess);
+}
+
+function scheduleRefresh(expiresInSeconds: number, onSuccess: (token: string) => void) {
+    if (refreshTimeoutId) {
+        clearTimeout(refreshTimeoutId);
+        refreshTimeoutId = null;
+    }
+
+    const timeTillRefresh = (expiresInSeconds - REFRESH_BUFFER_SECONDS) * 1000;
+
+    if (timeTillRefresh <= 0) {
+        // Expiring very soon or already into buffer zone, refresh immediately
+        refreshAuth();
+    } else {
+        refreshTimeoutId = setTimeout(() => {
+            refreshAuth();
+        }, timeTillRefresh);
+    }
+}
+
+function checkAndRefreshIfNeeded(onSuccess: (token: string) => void) {
+    const storedExpiry = localStorage.getItem(EXPIRY_KEY);
+    if (!storedExpiry) return;
+
+    const expiryTime = parseInt(storedExpiry);
+    const remainingSeconds = (expiryTime - Date.now()) / 1000;
+
+    if (remainingSeconds < REFRESH_BUFFER_SECONDS) {
+        // We are within the buffer window or expired
+        if (accessToken) {
+            refreshAuth();
+        }
+    } else {
+        // We are fine, but ensure scheduler is running if it was lost (e.g. reload?)
+        // Actually, initializeAuth calls scheduleRefresh, so likely fine.
+        // But if we just woke up, we might need to adjust the timer if it drifted?
+        // JS timers usually pause/delay on sleep.
+        // Re-scheduling is safe.
+        scheduleRefresh(remainingSeconds, onSuccess);
+    }
+}
+
+export function refreshAuth() {
+    if (tokenClient) {
+        console.log('Refreshing auth token...');
+        // prompt: '' is the key for silent refresh if user is already signed in
+        tokenClient.requestAccessToken({ prompt: '' });
+    }
 }
 
 export function signIn() {
@@ -93,6 +160,10 @@ export function getAccessToken() {
 
 export function signOut() {
     accessToken = null;
+    if (refreshTimeoutId) {
+        clearTimeout(refreshTimeoutId);
+        refreshTimeoutId = null;
+    }
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(EXPIRY_KEY);
     if (typeof google !== 'undefined' && google.accounts) {

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -395,7 +395,7 @@
                     <span>Photo Library</span>
                 </button>
                 <!-- Hidden file input for file picker fallback if library fails or just standard upload -->
-                <button class="big-btn glass-panel" onclick={() => fileInput.click()}>
+                <button class="big-btn glass-panel" onclick={() => fileInput?.click()}>
                     <div class="icon">📁</div>
                     <span>File</span>
                 </button>
@@ -411,7 +411,7 @@
                  {#each imagePreviews as preview}
                      <img src={preview} alt="Thumb" class="sheet-thumb" />
                  {/each}
-                 <button class="add-more-btn" onclick={() => fileInput.click()}>+</button>
+                <button class="add-more-btn" onclick={() => fileInput?.click()}>+</button>
              </div>
              
              {#if analyzing}


### PR DESCRIPTION
# Auth Persistence Improvements

## User Prompt
> There is a problem where auth really doesn't last at all for hte client. I'd like the user to stay logged in as long as possible to avoid ahving to re-authenticate all the time.

## Changes
- Implemented proactive token refresh in `src/lib/auth.ts`.
- Added `scheduleRefresh` to refresh token 5 minutes before expiry.
- Added `visibilitychange` listener to refresh token when tab becomes visible if near expiry.
- Improved `initializeAuth` to handle session restoration with accurate remaining time.
- Fixed TS errors in `src/routes/log/+page.svelte`.

## Artifacts
- [Implementation Plan](docs/auth_persistence/implementation_plan.md)
- [Walkthrough](docs/auth_persistence/walkthrough.md)
