### PR TITLE
chore: rename spreadsheet to TheFoodTrackerEventLog

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,13 +1,9 @@
-# Fix iOS App Icon and Add Meta Tag
+# Rename Spreadsheet to TheFoodTrackerEventLog
 
-## Summary
-This PR fixes the issue where the app icon was not appearing on the iOS homescreen. It adds the missing `mobile-web-app-capable` meta tag and converts the icon files from renamed JPEGs to actual PNG format, as iOS is strict about image formats.
+## Description
+Renamed the Google Sheet used for logging events from the generic "Events" to "TheFoodTrackerEventLog" to prevent naming collisions with users' existing Drive files.
 
-## Changes
-- Added `<meta name="mobile-web-app-capable" content="yes">` to `src/app.html`.
-- Converted `static/apple-touch-icon.png`, `static/android-chrome-192x192.png`, and `static/android-chrome-512x512.png` from JPEG to PNG format using `sips`.
+## User Prompts
+> The spreadsheet name is too generic - might collide with a sheet hte user has. Let's call it TheFoodTrackerEventLog to avoid collisions with the user's own documents.
 
-## Original User Prompt
-The app icon on iOS is still not working. I notice my chrome console says <meta name="apple-mobile-web-app-capable" content="yes"> is deprecated. Please include <meta name="mobile-web-app-capable" content="yes">
-
-Doesn't seem like this could be the culprit but something is making the app icon not load onto the homescreen.
+> Let's follow WORKFLOW.md and put this up as a PR

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -77,7 +77,7 @@ export async function ensureDataStructures() {
     const folderId = await findOrCreateFolder('FoodLog');
     console.log('Folder ID:', folderId);
 
-    const spreadsheetId = await findOrCreateFile('Events', folderId, 'application/vnd.google-apps.spreadsheet');
+    const spreadsheetId = await findOrCreateFile('TheFoodTrackerEventLog', folderId, 'application/vnd.google-apps.spreadsheet');
     console.log('Spreadsheet ID:', spreadsheetId);
 
     // Ensure "Events" tab exists (default is Sheet1)

--- a/tests/e2e/002-log-food/002-log-food.spec.ts
+++ b/tests/e2e/002-log-food/002-log-food.spec.ts
@@ -59,9 +59,9 @@ test('US-003 to US-010: User logs food flow', async ({ page }, testInfo) => {
             if (url.includes('foodlog') || url.includes('FoodLog')) {
                 // Search for Folder
                 await route.fulfill({ json: { files: [{ id: 'mock-folder-id', name: 'FoodLog' }] } });
-            } else if (url.includes('Events')) {
+            } else if (url.includes('TheFoodTrackerEventLog')) {
                 // Search for File
-                await route.fulfill({ json: { files: [{ id: 'mock-spreadsheet-id', name: 'Events' }] } });
+                await route.fulfill({ json: { files: [{ id: 'mock-spreadsheet-id', name: 'TheFoodTrackerEventLog' }] } });
             } else if (url.includes('uploadType=multipart')) {
                 // Upload
                 await route.fulfill({ json: { id: 'file-123', webViewLink: 'https://drive.mock/img.jpg', thumbnailLink: 'https://drive.mock/thumb.jpg' } });

--- a/tests/e2e/003-stats/003-stats.spec.ts
+++ b/tests/e2e/003-stats/003-stats.spec.ts
@@ -33,8 +33,8 @@ test('US-012: Stats persist after reload', async ({ page }, testInfo) => {
         if (url.includes('drive/v3/files')) {
             if (url.includes('foodlog') || url.includes('FoodLog')) {
                 await route.fulfill({ json: { files: [{ id: 'mock-folder-id', name: 'FoodLog' }] } });
-            } else if (url.includes('Events')) {
-                await route.fulfill({ json: { files: [{ id: 'mock-spreadsheet-id', name: 'Events' }] } });
+            } else if (url.includes('TheFoodTrackerEventLog')) {
+                await route.fulfill({ json: { files: [{ id: 'mock-spreadsheet-id', name: 'TheFoodTrackerEventLog' }] } });
             } else {
                 await route.fulfill({ json: { id: 'new-mock-id' } });
             }

--- a/tests/e2e/008-date-nav/008-date-nav.spec.ts
+++ b/tests/e2e/008-date-nav/008-date-nav.spec.ts
@@ -52,8 +52,8 @@ test('US-023: Date Navigation', async ({ page }, testInfo) => {
             // Standard file mocks
             if (url.includes('foodlog') || url.includes('FoodLog')) {
                 await route.fulfill({ json: { files: [{ id: 'mock-folder-id', name: 'FoodLog' }] } });
-            } else if (url.includes('Events')) {
-                await route.fulfill({ json: { files: [{ id: 'mock-spreadsheet-id', name: 'Events' }] } });
+            } else if (url.includes('TheFoodTrackerEventLog')) {
+                await route.fulfill({ json: { files: [{ id: 'mock-spreadsheet-id', name: 'TheFoodTrackerEventLog' }] } });
             } else {
                 await route.fulfill({ json: { id: 'new-mock-id' } });
             }


### PR DESCRIPTION
# Rename Spreadsheet to TheFoodTrackerEventLog

## Description
Renamed the Google Sheet used for logging events from the generic "Events" to "TheFoodTrackerEventLog" to prevent naming collisions with users' existing Drive files.

## User Prompts
> The spreadsheet name is too generic - might collide with a sheet hte user has. Let's call it TheFoodTrackerEventLog to avoid collisions with the user's own documents.

> Let's follow WORKFLOW.md and put this up as a PR
