### PR TITLE
docs: Offline Support Design

### DIFF
--- a/OFFLINE_SUPPORT.md
+++ b/OFFLINE_SUPPORT.md
@@ -40,8 +40,11 @@ The synchronization logic is bidirectional but "Local-First".
 2.  **Process**:
     -   Query IndexedDB for all events where `syncStatus === 'pending'`.
     -   Sort by `timestamp`.
-    -   Loop through events and call `sheets.appendRow`.
-    -   **On Success**: Update IndexedDB event to `syncStatus: 'synced'`.
+    -   **Batch Append**:
+        -   Collect all pending event payloads into a single array.
+        -   Call `sheets.appendRow` (or a new `appendRows`) with the batch of values.
+        -   *Note*: The Google Sheets API `append` endpoint accepts multiple rows in a single request body (`values: [[row1], [row2], ...]`). This reduces N network calls to 1.
+    -   **On Success**: Update all synced events in IndexedDB to `syncStatus: 'synced'`.
     -   **On Failure**: Leave as `pending`. Update global "Sync Health" state.
 
 #### C. Inbound Sync (Hydration & Replay)


### PR DESCRIPTION
# Offline Support Design

This PR introduces the design document for implementing offline support using IndexedDB and Google Sheets synchronization.

## User Prompt

Read CLEANUP.md DEVELOPMENT.md and WORKFLOW.md. I'd like to address cleanup item #2 by adding an indexed db table that is a write-through cache to the underlying google sheet. On load, the app should replay from cache and fetch from the sheet only those actions which are new on the server. 

Write a design doc OFFLINE_SUPPORT.md that describes the setup in detail, including how idempotency will work, how this will work if multiple clients are disconnected and log different food items, what UI is needed to indicate an offline/out of sync state, and any considerations on the size limit of a single google sheet and how to use multiple subsheets in the spreadsheet to enable evading the single google sheet limit. 

Read WORKFLOW.md and follow procedures to put this new design document up as a PR.

## Changes

-   Added `OFFLINE_SUPPORT.md`: Detailed architecture for Local-First Sync, Idempotency, and Sheet Partitioning.
