### PR TITLE
fix: Camera Button Native Picker & Voice Icons

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,20 +1,13 @@
-# Execute Cleanup Plan
+# Fix Camera Button and Voice Icons
 
-This PR addresses the final items in `CLEANUP_PLAN.md`:
-1.  **Console Cleanup**: Removed verbose logging from `sync-manager.ts`, `sheets.ts`, and `google-photos.ts`.
-2.  **Type Hardening**: 
-    - Added `GoogleDriveFile` interface to `sheets.ts`.
-    - Added `PickerMediaItemResponse` and `LibraryMediaItemResponse` interfaces to `google-photos.ts`.
-    - Created `src/types/exifr.d.ts` to type the `exifr` library.
-    - Removed `@ts-ignore` and added proper casting in `log/+page.svelte`.
-3.  **Error Visibility**: Verified that sync errors are surfaced to the Network Settings UI via `syncError` state.
+## Description
+This PR addresses two issues:
+1.  Converts the camera button back into a file chooser button using `capture="environment"` to trigger the native iOS camera interface, while retaining the existing icon. This simplifies the implementation by removing the custom camera UI overlay.
+2.  Replaces missing icons in the Voice Recorder dialog with inline SVGs for 'Stop & Analyze' and 'Analyze'.
 
-## User Prompt
+## Original User Prompts
+> In the screen with logging buttons, there are two problems.
+> (1) we removed the filechooser button. Let's convert the camera button into a file chooser button *without* changing hte icon and use the form of file chooser that will cause ios to put taking a photo first.
+> (2) in the voice dialog, the stop and analyze button refers to a non-existant icon, let's find a good one instead.
 
-Let's attempt to finish all items in CLEANUP_PLAN.md. 
-
-Review all console messages. For any the user should be aware of, put htem in the error view we built for the network settings screen to surface them. For those that are useless debugging, remove them. 
-
-Review all typescript shortcuts and clean up as many as possible.
-
-Review WORKFLOW.md and follow it rigidly to create a PR for this final set of cleanup steps. If hte plan is resolved, delete the file as part of this PR.
+> doesn't compile, did you npm run check?

--- a/src/lib/components/ui/VoiceRecorder.svelte
+++ b/src/lib/components/ui/VoiceRecorder.svelte
@@ -220,9 +220,11 @@
         <div class="controls">
             <button class="action-btn stop" onclick={done}>
                 {#if recognizing}
-                   <span class="icon">stop_circle</span> Stop & Analyze
+                   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><rect x="9" y="9" width="6" height="6"></rect></svg>
+                   Stop & Analyze
                 {:else}
-                   <span class="icon">check_circle</span> Analyze
+                   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                   Analyze
                 {/if}
             </button>
             <button class="action-btn cancel" onclick={close}>Cancel</button>

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -17,8 +17,8 @@
   import VoiceRecorder from '$lib/components/ui/VoiceRecorder.svelte';
 
   let fileInput = $state<HTMLInputElement>();
-  let videoElement = $state<HTMLVideoElement>();
-  let stream: MediaStream | null = null;
+  let cameraInput = $state<HTMLInputElement>();
+
   
   type LogMode = 'IDLE' | 'CAMERA' | 'VOICE' | 'TEXT' | 'LIBRARY';
   let currentMode = $state<LogMode>('IDLE');
@@ -205,47 +205,7 @@
       }
   }
 
-  async function startCamera() {
-    currentMode = 'CAMERA';
-    try {
-        stream = await navigator.mediaDevices.getUserMedia({ 
-            video: { facingMode: 'environment' } 
-        });
-        setTimeout(() => {
-            if (videoElement) videoElement.srcObject = stream;
-        }, 100);
-    } catch (e) {
-        console.error('Camera failed', e);
-        toasts.error('Could not access camera');
-        currentMode = 'IDLE';
-    }
-  }
 
-  function stopCamera() {
-    if (stream) {
-        stream.getTracks().forEach(track => track.stop());
-        stream = null;
-    }
-    currentMode = 'IDLE';
-  }
-
-  function capturePhoto() {
-    if (!videoElement) return;
-    const canvas = document.createElement('canvas');
-    canvas.width = videoElement.videoWidth;
-    canvas.height = videoElement.videoHeight;
-    const ctx = canvas.getContext('2d');
-    ctx?.drawImage(videoElement, 0, 0);
-    
-    canvas.toBlob(blob => {
-        if (blob) {
-            const file = new File([blob], `capture-${Date.now()}.jpg`, { type: 'image/jpeg' });
-            addImage(file);
-        }
-    }, 'image/jpeg');
-
-    stopCamera();
-  }
 
   async function handleFileSelect(e: Event) {
     const target = e.target as HTMLInputElement;
@@ -532,7 +492,8 @@
   function handleModeSelect(mode: LogMode) {
       if (mode === 'IDLE') return;
       if (mode === 'CAMERA') {
-          startCamera();
+          // Trigger native camera capture
+          cameraInput?.click();
       } else if (mode === 'LIBRARY') {
           handleGooglePhotosPick();
       } else {
@@ -542,16 +503,7 @@
 </script>
 
 <div class="log-page">
-    {#if currentMode === 'CAMERA'}
-        <div class="camera-ui">
-             <video bind:this={videoElement} autoplay playsinline muted></video>
-             <div class="cam-controls">
-                 <button class="cam-btn capture" onclick={capturePhoto} aria-label="Capture photo"></button>
-                 <button class="cam-btn cancel" onclick={stopCamera}>Cancel</button>
-             </div>
-        </div>
-    {:else}
-        <!-- Pre-capture State / Unified Grid -->
+    <!-- Unified Grid -->
         <div class="start-ui">
             <h1>Log Food</h1>
             
@@ -571,13 +523,13 @@
                 />
             {/if}
             
-            <input type="file" accept="image/*" multiple bind:this={fileInput} onchange={handleFileSelect} hidden />
-        </div>
-    {/if}
+    <input type="file" accept="image/*" multiple bind:this={fileInput} onchange={handleFileSelect} hidden />
+    <input type="file" accept="image/*" capture="environment" bind:this={cameraInput} onchange={handleFileSelect} hidden />
+</div>
 
-    <LogSheet open={sheetOpen} onClose={handleCloseSheet}>
-         <div class="sheet-content">
-             <div class="preview-strip">
+<LogSheet open={sheetOpen} onClose={handleCloseSheet}>
+     <div class="sheet-content">
+         <div class="preview-strip">
                  {#each imagePreviews as preview}
                      <img 
                        src={preview} 
@@ -670,7 +622,7 @@
                               <textarea bind:value={userCorrection} placeholder="e.g. It was 2 eggs, not 3" rows="2" class="bg-input"></textarea>
                               <button class="primary-btn small" onclick={handleReanalyze} disabled={!userCorrection}>Retry</button>
                          </div>
-                      {/if}
+                          {/if}
 
                       <button class="save-btn-primary" onclick={handleSubmit} disabled={isSaving}>
                           {isSaving ? 'Saving...' : 'Save Entry'}
@@ -704,48 +656,7 @@
 
 
 
-    /* Camera UI */
-    .camera-ui {
-        position: fixed;
-        top: 0; 
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: black;
-        z-index: 50;
-    }
-    
-    video {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
-    
-    .cam-controls {
-        position: absolute;
-        bottom: 50px;
-        width: 100%;
-        display: flex;
-        justify-content: center;
-        gap: 40px;
-        align-items: center;
-    }
-    
-    .cam-btn.capture {
-        width: 80px;
-        height: 80px;
-        border-radius: 50%;
-        border: 5px solid rgba(255,255,255,0.5);
-        background: white;
-    }
-    
-    .cam-btn.cancel {
-        background: rgba(0,0,0,0.5);
-        color: white;
-        border: 1px solid white;
-        padding: 10px 20px;
-        border-radius: 20px;
-    }
+
 
     /* Sheet Content */
     .sheet-content {


### PR DESCRIPTION
# Fix Camera Button and Voice Icons

## Description
This PR addresses two issues:
1.  Converts the camera button back into a file chooser button using `capture="environment"` to trigger the native iOS camera interface, while retaining the existing icon. This simplifies the implementation by removing the custom camera UI overlay.
2.  Replaces missing icons in the Voice Recorder dialog with inline SVGs for 'Stop & Analyze' and 'Analyze'.

## Original User Prompts
> In the screen with logging buttons, there are two problems.
> (1) we removed the filechooser button. Let's convert the camera button into a file chooser button *without* changing hte icon and use the form of file chooser that will cause ios to put taking a photo first.
> (2) in the voice dialog, the stop and analyze button refers to a non-existant icon, let's find a good one instead.

> doesn't compile, did you npm run check?
