### PR TITLE
fix: refresh auth on global interaction

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,6 @@
+Fix Auth Refresh on Interaction
+
+## User Prompt
+Auth is not working the way I expected it to. When I come back to the app after a long absence, and try to log a food, I am never authenticated, and have to sign out and in again.
+
+I thought we'd changed it so that on every click we would refresh auth. If that was true, auth would be refreshed when we enter the log screen and I should not see the problem. Auth refresh does *require* a click in the browser, so if we're doing it without a user action driving it that could be the problem.

--- a/docs/auth_refresh_implementation_plan.md
+++ b/docs/auth_refresh_implementation_plan.md
@@ -1,0 +1,27 @@
+# Auth Refresh on Click Implementation Plan
+
+## Problem
+Users returning to the app after a long absence (>1h, <48h) find their session expired. The automatic background refresh might be failing due to lack of user gesture (browser restrictions on `requestAccessToken` or 3rd party cookie blocking), requiring a full sign-out/sign-in.
+
+## Solution
+Attach a global `click` listener in the root layout that triggers `ensureValidToken()`. This ensures that when a user interacts with the app (e.g., clicking "Log Food" or "Save"), the token refresh process is initiated *with* a user gesture context, improving reliability. Since `ensureValidToken` dedupes requests via `refreshPromise`, this is efficient and safe.
+
+## Proposed Changes
+
+### [Layout]
+#### [MODIFY] [src/routes/+layout.svelte](file:///Users/anicolao/projects/antigravity/food/src/routes/+layout.svelte)
+- Add `onMount` event listener for `click` (capture phase).
+- Handler calls `ensureValidToken()` from `$lib/auth`.
+- Log the preemptive check for debugging.
+
+## Verification Plan
+
+### Automated
+- We cannot easily test "user gesture requirements" in a headless browser standard test, but we can verify that `ensureValidToken` is called on click.
+- We will rely on manual verification or existing auth tests to ensure no regression.
+
+### Manual Verification
+1.  **Simulate Expiry**: Manually set `food_log_token_expiry` in localStorage to a time in the past (but within 48h).
+2.  **Click Interaction**: Click anywhere in the app.
+3.  **Verify Refresh**: Check console logs for "Refreshing auth token..." and confirm it succeeds without signing out.
+4.  **Verify Sync**: Perform an action (like Logging) and ensure it succeeds immediately.

--- a/docs/auth_refresh_walkthrough.md
+++ b/docs/auth_refresh_walkthrough.md
@@ -1,0 +1,17 @@
+# Auth Refresh on Click Walkthrough
+
+## Changes
+- **Modified `src/routes/+layout.svelte`**:
+    - Added global `document.addEventListener('click', ...)` in `onMount`.
+    - Handler calls `ensureValidToken()` from `$lib/auth`.
+    - Added cleanup logic in `$effect` return.
+
+## Verification
+### Manual Verification Steps
+1.  **Wait for Expiry**: Allow token to expire (or artificially set expiry in localStorage to past).
+2.  **Click anywhere**: Click on the "Log Food" button or any neutral area.
+3.  **Observe Console**: Check DevTools console for `[Auth] Token expired/buffered... Refreshing...` followed by successful token acquisition.
+4.  **No Sign-out**: Ensure the user is NOT signed out and can proceed with logging immediately.
+
+## Automated Tests
+- No new E2E tests added as "user gesture" context is specific to browser security models and hard to mock reliably in headless Chrome without actually triggering the same security constraints. The existing auth unit tests ensure `ensureValidToken` logic itself is sound.

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,7 +9,7 @@
 	import { page } from '$app/stores';
 	import { getTransitionDirection, getTransitionParams } from '$lib/transitions';
 	import { onMount } from 'svelte';
-    import { initializeAuth } from '$lib/auth';
+    import { initializeAuth, ensureValidToken } from '$lib/auth';
     import { afterNavigate, beforeNavigate } from '$app/navigation';
     import { getAllEvents } from '$lib/db';
     import { syncManager } from '$lib/sync-manager';
@@ -65,6 +65,19 @@
 		transitionsEnabled = true;
 	});
 
+    // Global click listener to ensure auth is fresh on user interaction
+    // This solves the issue of stale tokens on return without requiring a full reload or sign-out
+    $effect(() => {
+        const handleInteraction = () => {
+             ensureValidToken().catch(e => console.warn('[Auth] Background refresh failed', e));
+        };
+        document.addEventListener('click', handleInteraction, true); // Capture phase to likely happen first
+        
+        return () => {
+             document.removeEventListener('click', handleInteraction, true);
+        };
+    });
+
     // Handle history updates for direction calculation    // Handle history updates for direction calculation
     import { transitionSnapshots } from '$lib/transitions';
 
@@ -95,6 +108,7 @@
             });
         }
     });
+
 
 </script>
 


### PR DESCRIPTION
Fix Auth Refresh on Interaction

## User Prompt
Auth is not working the way I expected it to. When I come back to the app after a long absence, and try to log a food, I am never authenticated, and have to sign out and in again.

I thought we'd changed it so that on every click we would refresh auth. If that was true, auth would be refreshed when we enter the log screen and I should not see the problem. Auth refresh does *require* a click in the browser, so if we're doing it without a user action driving it that could be the problem.
