### PR TITLE
Fix Flaky E2E Tests: Sync Icon & Nutrition Details

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,6 +1,17 @@
-Fix Auth Refresh on Interaction
+# Fix Flaky E2E Tests
 
 ## User Prompt
-Auth is not working the way I expected it to. When I come back to the app after a long absence, and try to log a food, I am never authenticated, and have to sign out and in again.
+The e2e tests are a little flaky on the cloud sync icon still. There was a recent commit meant to address this, but I've seen it again in production on 013-detailed-nutrition/013-detailed-nutrition.spec.ts:5 where the cloud icon showed syncing instead of sync. 
 
-I thought we'd changed it so that on every click we would refresh auth. If that was true, auth would be refreshed when we enter the log screen and I should not see the problem. Auth refresh does *require* a click in the browser, so if we're doing it without a user action driving it that could be the problem.
+I also saw an oddball flake on 002-log-food/002-log-food.spec.ts:7 where the + icon was missing from the nutrition facts detail on a food log. 
+
+Let's add checks to these tests to ensure cloud sync state is right and the icon is loaded before taking the corresponding screenshots.
+
+## Changes
+- **013-detailed-nutrition.spec.ts**: Added explicit wait for `[data-status="synced"]` after saving entry to prevent race condition with screenshots.
+- **002-log-food.spec.ts**: Added explicit wait for `.icon-toggle` visibility after analysis to ensure nutrition form is fully loaded.
+
+## Verification
+Ran local tests:
+- `tests/e2e/013-detailed-nutrition/013-detailed-nutrition.spec.ts`: Passed
+- `tests/e2e/002-log-food/002-log-food.spec.ts`: Passed

--- a/docs/walkthrough_flaky_e2e.md
+++ b/docs/walkthrough_flaky_e2e.md
@@ -1,0 +1,20 @@
+# Fix Flaky E2E Tests Walkthrough
+
+## Use Case
+Improving the stability of E2E tests in CI by addressing reported flakes where screenshots captured transient states (syncing icon or missing UI elements).
+
+## Changes
+
+### [013-detailed-nutrition.spec.ts](file:///Users/anicolao/projects/antigravity/food/tests/e2e/013-detailed-nutrition/013-detailed-nutrition.spec.ts)
+- Added `await expect(page.locator('[data-status="synced"]')).toBeVisible();` after saving an entry to ensure the sync process completes before any implicit or explicit assertions that rely on the final state.
+
+### [002-log-food.spec.ts](file:///Users/anicolao/projects/antigravity/food/tests/e2e/002-log-food/002-log-food.spec.ts)
+- Added `await expect(page.locator('.icon-toggle')).toBeVisible();` after analysis verification to ensure icons are loaded.
+
+## Verification Results
+
+### Automated Tests
+Ran the affected tests locally to confirm they pass.
+
+- `tests/e2e/013-detailed-nutrition/013-detailed-nutrition.spec.ts`: **Passed**
+- `tests/e2e/002-log-food/002-log-food.spec.ts`: **Passed**

--- a/tests/e2e/002-log-food/002-log-food.spec.ts
+++ b/tests/e2e/002-log-food/002-log-food.spec.ts
@@ -151,6 +151,9 @@ test('US-003 to US-010: User logs food flow', async ({ page }, testInfo) => {
     // Wait for Gemini Mock
     await expect(page.getByLabel('Log Description')).toHaveValue('Mock Apple');
 
+    // Ensure nutrition form icons are loaded (User reported flake)
+    await expect(page.locator('.icon-toggle')).toBeVisible();
+
     await tester.step('analysis', {
         description: 'AI Analysis Received',
         verifications: [

--- a/tests/e2e/013-detailed-nutrition/013-detailed-nutrition.spec.ts
+++ b/tests/e2e/013-detailed-nutrition/013-detailed-nutrition.spec.ts
@@ -144,6 +144,8 @@ test('013-detailed-nutrition: Log and Edit Detailed Nutrition', async ({ page })
             check: async () => {
                 await page.getByRole('button', { name: 'Save Entry' }).click();
                 await expect(page).toHaveURL(/\/$/);
+                // Ensure sync completes before potential screenshots (User reported flake)
+                await expect(page.locator('[data-status="synced"]')).toBeVisible();
             }
         }]
     });


### PR DESCRIPTION
# Fix Flaky E2E Tests

## User Prompt
The e2e tests are a little flaky on the cloud sync icon still. There was a recent commit meant to address this, but I've seen it again in production on 013-detailed-nutrition/013-detailed-nutrition.spec.ts:5 where the cloud icon showed syncing instead of sync. 

I also saw an oddball flake on 002-log-food/002-log-food.spec.ts:7 where the + icon was missing from the nutrition facts detail on a food log. 

Let's add checks to these tests to ensure cloud sync state is right and the icon is loaded before taking the corresponding screenshots.

## Changes
- **013-detailed-nutrition.spec.ts**: Added explicit wait for `[data-status="synced"]` after saving entry to prevent race condition with screenshots.
- **002-log-food.spec.ts**: Added explicit wait for `.icon-toggle` visibility after analysis to ensure nutrition form is fully loaded.

## Verification
Ran local tests:
- `tests/e2e/013-detailed-nutrition/013-detailed-nutrition.spec.ts`: Passed
- `tests/e2e/002-log-food/002-log-food.spec.ts`: Passed
