### PR TITLE
fix(auth): restore missing Gemini API scope

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,94 +1,40 @@
-# Privacy Policy Implementation
+# Fix Gemini API 403 Forbidden Error
 
-This PR implements the Privacy Policy for Food Sheets, ensuring compliance and transparency for users.
+## Description
+Restores the `generative-language.retriever` OAuth scope which is required for the Gemini API `generateContent` method. This scope was missing, causing 403 Forbidden errors.
 
 ## Changes
-- **New Page**: Added `/privacy` route with the full privacy policy.
-- **Documentation**: Added `PRIVACY.md` to the repository root.
-- **Readme**: linked the privacy policy in `README.md`.
-- **Docs**: Added implementation plan and walkthrough to `docs/privacy/`.
+- **src/lib/auth.ts**: Added `https://www.googleapis.com/auth/generative-language.retriever` to `SCOPES`.
+- **src/routes/privacy/+page.svelte**: Updated privacy policy to document this scope.
 
-## User Request
-Preparing for launch, I had Gemini create a privacy policy. We need to serve this from somewhere, I suggest from /food/privacy, and include it int he top level of the repo and link it from the README.md.
-
-Also, we need to somehow connect this to our OAuth setup. You may need to provide me with instructions for that.
-
-Here is the proposed policy:
-# Privacy Policy for Food Sheets
-
-**Last Updated:** January 18, 2026
-
-## The Short Version
-**Food Sheets** is an Open Source application designed with a "Privacy First" architecture.
-* **No Developer Servers:** We do not own a database. We do not store your data.
-* **Your Drive, Your Data:** All food logs, photos, and nutrition stats are saved directly to *your* personal Google Drive.
-* **Sandboxed Access:** The app is restricted so it can *only* access the specific files it creates. It cannot read your other personal spreadsheets or documents.
-
----
-
-## 1. Data Collection and Storage Architecture
-
-### Sandboxed Google Drive Access
-We utilize the `drive.file` permission scope, which provides a "Strictly Sandboxed" level of access.
-* **What we DO:** The application creates a specific Google Sheet (for your logs) and a folder (for your food photos) in your Google Drive. We can read and edit *only* these specific files.
-* **What we DO NOT:** We have absolutely no access to existing spreadsheets, tax documents, or any other files in your Google Drive that were not created by Food Sheets.
-
-### Photos and Camera
-We use the system's native Photo Picker (`photospicker.mediaitems.readonly`).
-* **User-Initiated Only:** The application does not have general access to your camera roll. It can only process the specific images you explicitly tap to select for analysis.
-* **No Background Scanning:** We do not scan your library in the background.
-
-## 2. Artificial Intelligence & Semantic Memory
-
-To estimate calories and answer questions about your diet (e.g., "What did I eat last Tuesday?"), Food Sheets uses the **Google Gemini API**.
-
-### Image Analysis
-When you select a food photo, it is sent to the Gemini API for analysis.
-* **Privacy Protection:** We utilize the Enterprise/Paid tier of the Gemini API. This means Google **does not** use your photos or prompts to train their public AI models.
-* **Retention:** Google may temporarily retain API logs for up to 55 days solely for abuse monitoring (to prevent the generation of illegal content), after which they are deleted.
-
-### Semantic Memory (The "Retriever")
-The application uses the `generative-language.retriever` scope to create a "Private Corpus" (a searchable index) of your food logs.
-* **Purpose:** This allows the AI to "remember" your past meals to provide better context and answer your questions about your history.
-* **Isolation:** This index is stored securely within the Google Gemini ecosystem and is strictly isolated to your authenticated account. It is not shared with other users.
-
-## 3. Account & Authorization
-
-### Google Sign-In (OAuth)
-We use Google OAuth 2.0 to authenticate you. This allows the application to act as an agent on your behalf using your own Google Account.
-* **Your Control:** You authorize the application to perform specific actions (like "Save to Drive") using your own account's quota.
-* **No Password Access:** We never see or store your Google password. The authorization is handled securely via a token stored in your device's secure keychain.
-
-## 4. Third-Party Services & Compliance
-
-The application relies on the following platform services to function:
-* **Google Drive API:** For file storage.
-* **Google Gemini API:** For nutritional analysis and memory.
-
-### Google Limited Use Policy
-Food Sheets' use and transfer to any other app of information received from Google APIs will adhere to the [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy), including the Limited Use requirements.
-
-## 5. Analytics and Tracking
-To maintain strict privacy:
-* **No Third-Party Analytics:** We do not use tools like Google Analytics, Mixpanel, or Facebook Pixel.
-* **No Advertising ID:** We do not collect your device's Advertising ID.
-* **Crash Reporting:** Minimal anonymous crash logs may be sent to Apple/Google (based on your system settings) to help us fix bugs, but these contain no personal health data.
-
-## 6. AI Accuracy Disclaimer
-This application uses Artificial Intelligence to estimate nutritional information.
-* **Estimates Only:** AI-generated calorie and macro counts are estimates and may not be 100% accurate.
-* **Not Medical Advice:** Do not rely on these estimates for critical medical decisions (e.g., insulin dosing). Always verify the data manually if you have strict dietary requirements.
-
-## 7. Your Rights (Data Deletion)
-Since your data resides in your own Google Drive and Gemini Corpus:
-1.  **Full Control:** You can delete your "Food Sheets" folder in Google Drive at any time to remove your logs.
-2.  **Revoking Access:** You can revoke the app's access to your account at any time via your Google Account security settings (`myaccount.google.com/permissions`).
-
-## 8. Changes to This Policy
-Because the code is Open Source, any changes to how data is handled will be visible in the public code repository. If we make material changes to this policy, we will notify users through an app update.
-
-## 9. Contact Us
-If you have questions about this privacy policy or the open-source nature of the project, please contact:
-
-**[Your Name / Support Email]**
-[Link to GitHub Repository]
+## Context
+Original User Request:
+> Looks like I got too aggressive removing scopes. I am now getting 
+> POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent 403 (Forbidden)
+> window.fetch @ fetcher.js?v=8618c5bb:66
+> analyzeFood @ gemini.ts:112
+> await in analyzeFood
+> handleTextAnalyze @ +page.svelte:333
+> analyze @ +page.svelte:533
+> (anonymous) @ chunk-5QCNSHAL.js?v=8618c5bb:3385
+> done @ VoiceRecorder.svelte:201
+> handle_event_propagation @ chunk-YTF3ZZG2.js?v=8618c5bb:4402Understand this error
+> +page.svelte:374 Error: Gemini API Error: 403 - {
+>   "error": {
+>     "code": 403,
+>     "message": "Request had insufficient authentication scopes.",
+>     "status": "PERMISSION_DENIED",
+>     "details": [
+>       {
+>         "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+>         "reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT",
+>         "metadata": {
+>           "method": "google.ai.generativelanguage.v1beta.GenerativeService.GenerateContent",
+>           "service": "generativelanguage.googleapis.com"
+>         }
+>       }
+>     ]
+>   }
+> }
+> 
+> What is the *minimum* scope we require for this API to succeed? Add it to the OAuth scopes and privacy policies.

--- a/docs/implementation_plan_gemini_scopes.md
+++ b/docs/implementation_plan_gemini_scopes.md
@@ -1,0 +1,31 @@
+# Implementation Plan - Restore Gemini API OAuth Scope
+
+The user is experiencing 403 Forbidden errors when using the Gemini API. This is caused by insufficient OAuth scopes after a recent cleanup. This plan restores the minimum required scope for the Gemini API.
+
+## User Review Required
+
+> [!IMPORTANT]
+> This change will likely require you (and all users) to sign out and sign back in to grant the new permission.
+
+## Proposed Changes
+
+### Auth Configuration
+
+#### [MODIFY] [auth.ts](file:///Users/anicolao/projects/antigravity/food/src/lib/auth.ts)
+- Add `https://www.googleapis.com/auth/generative-language.retriever` to the `SCOPES` list.
+- Rationale: This is the standard scope needed for Gemini API interaction when using OAuth.
+
+### Documentation & Privacy
+
+#### [MODIFY] [privacy/+page.svelte](file:///Users/anicolao/projects/antigravity/food/src/routes/privacy/+page.svelte)
+- Update the "Artificial Intelligence" section to explicitly mention the `generative-language.retriever` scope.
+- Explain that this permissions allows the "Food Sheets" app to send prompts to the AI service on your behalf.
+- Enforce the "Cannot vs Does Not" pattern: Clarify that while this scope is needed, it effectively limits us to the Generative Language service and doesn't grant broad access to your Google Cloud projects.
+
+## Verification Plan
+
+### Manual Verification
+1.  **Sign Out**: Manually sign out of the application to clear the old token.
+2.  **Sign In**: Sign in again.
+3.  **Check Permissions**: Verify the Google consent screen asks for "Manage your own generative language data" (or similar phrasing).
+4.  **Test Analysis**: Use the "Analyze Food" feature (e.g. by typing "an apple" in the log page) and confirm it succeeds without a 403 error.

--- a/docs/walkthrough_gemini_scopes.md
+++ b/docs/walkthrough_gemini_scopes.md
@@ -1,0 +1,27 @@
+# Verification: Gemini API Scope Restoration
+
+I have restored the `generative-language.retriever` scope to the application's authentication configuration. This should resolve the 403 Forbidden errors when using Gemini features.
+
+## Changes Made
+- **[auth.ts](file:///Users/anicolao/projects/antigravity/food/src/lib/auth.ts)**: Added `https://www.googleapis.com/auth/generative-language.retriever` to the OAuth scopes list.
+- **[privacy/+page.svelte](file:///Users/anicolao/projects/antigravity/food/src/routes/privacy/+page.svelte)**: Updated the privacy policy to explicitly list this scope and its purpose.
+
+## Verification Steps
+
+### 1. Re-Authenticate (CRITICAL)
+For the new scope to take effect, you **must** sign out and sign back in. The existing token in your local storage does not have the new permission.
+
+1.  Open the application.
+2.  Go to the settings or user menu and click **Sign Out**.
+3.  Click **Sign In** with Google.
+4.  **Verify Consent Screen**: When the Google popup appears, ensure it asks for permission to "Manage your own generative language data" (or similar wording).
+
+### 2. Test Food Analysis
+1.  Navigate to the `/log` page.
+2.  Type a text description (e.g., "a banana") into the input box and press Enter.
+    *   *Alternatively, upload an image if you prefer.*
+3.  **Confirm Success**: The "Analyzing..." state should resolve into a nutrition card without throwing a `403 Forbidden` error.
+
+### 3. Check Privacy Policy
+1.  Navigate to the `/privacy` page.
+2.  Verify that the "Artificial Intelligence" section now mentions the `generative-language.retriever` scope.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,7 +5,8 @@ import { base } from '$app/paths';
 export const GOOGLE_CLIENT_ID = (import.meta.env && import.meta.env.VITE_GOOGLE_OAUTH_ID) || undefined;
 export const SCOPES = [
     'https://www.googleapis.com/auth/drive.file',
-    'https://www.googleapis.com/auth/photospicker.mediaitems.readonly'
+    'https://www.googleapis.com/auth/photospicker.mediaitems.readonly',
+    'https://www.googleapis.com/auth/generative-language.retriever'
 ].join(' ');
 
 export interface UserProfile {

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -37,6 +37,7 @@
         <p>To estimate calories, Food Sheets uses the <strong>Google Gemini API</strong>.</p>
 
         <h3>Image Analysis</h3>
+        <p>We utilize the <code>generative-language.retriever</code> permission scope to access the Gemini API.</p>
         <p>When you select a food photo, it is sent to the Gemini API for analysis.</p>
         <ul>
             <li><strong>Direct Connection:</strong> The app connects directly to Google's API using your personal credentials. No developer server sits in the middle.</li>


### PR DESCRIPTION
# Fix Gemini API 403 Forbidden Error

## Description
Restores the `generative-language.retriever` OAuth scope which is required for the Gemini API `generateContent` method. This scope was missing, causing 403 Forbidden errors.

## Changes
- **src/lib/auth.ts**: Added `https://www.googleapis.com/auth/generative-language.retriever` to `SCOPES`.
- **src/routes/privacy/+page.svelte**: Updated privacy policy to document this scope.

## Context
Original User Request:
> Looks like I got too aggressive removing scopes. I am now getting 
> POST https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent 403 (Forbidden)
> window.fetch @ fetcher.js?v=8618c5bb:66
> analyzeFood @ gemini.ts:112
> await in analyzeFood
> handleTextAnalyze @ +page.svelte:333
> analyze @ +page.svelte:533
> (anonymous) @ chunk-5QCNSHAL.js?v=8618c5bb:3385
> done @ VoiceRecorder.svelte:201
> handle_event_propagation @ chunk-YTF3ZZG2.js?v=8618c5bb:4402Understand this error
> +page.svelte:374 Error: Gemini API Error: 403 - {
>   "error": {
>     "code": 403,
>     "message": "Request had insufficient authentication scopes.",
>     "status": "PERMISSION_DENIED",
>     "details": [
>       {
>         "@type": "type.googleapis.com/google.rpc.ErrorInfo",
>         "reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT",
>         "metadata": {
>           "method": "google.ai.generativelanguage.v1beta.GenerativeService.GenerateContent",
>           "service": "generativelanguage.googleapis.com"
>         }
>       }
>     ]
>   }
> }
> 
> What is the *minimum* scope we require for this API to succeed? Add it to the OAuth scopes and privacy policies.
