### PR TITLE
Fix upload completed projection update

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,12 +1,49 @@
-Fix Flaky E2E Tests (Log Again & Favourites)
-
-## Description
-This PR hardens the `014-log-again.spec.ts` E2E test to resolve reported flakiness.
+# Fix: Upload Completion Race
 
 ## Changes
-- Added explicit `toBeVisible()` checks before clicking 'Log new food entry', 'Log Again', and 'Favourites'.
-- This ensures the UI is hydration-stable and interactive before the test attempts to interact with it, preventing potential race conditions during heavy load or slower CI runs.
+- Update projections to attach `media/uploadCompleted` URLs to entries that reference pending media IDs.
+- Mark the upload race as fixed in `docs/DESIGN_REVIEW.md`.
 
-## Verification
-- Ran `014-log-again.spec.ts` 20 times locally with 100% pass rate.
-- Ran full E2E suite (`npm run test:e2e`) with 100% pass rate.
+## Testing
+- Not run (not requested).
+
+## Questions / Open Issues
+- None.
+
+## Original User Prompt(s)
+> # AGENTS.md instructions for /Users/anicolao/projects/antigravity/food-fixups
+>
+> <INSTRUCTIONS>
+> ## Skills
+> A skill is a set of local instructions to follow that is stored in a `SKILL.md` file. Below is the list of skills that can be used. Each entry includes a name, description, and file path so you can open the source for full instructions when using a specific skill.
+> ### Available skills
+> - skill-creator: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Codex's capabilities with specialized knowledge, workflows, or tool integrations. (file: /Users/anicolao/.codex/skills/.system/skill-creator/SKILL.md)
+> - skill-installer: Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub repo path. Use when a user asks to list installable skills, install a curated skill, or install a skill from another repo (including private repos). (file: /Users/anicolao/.codex/skills/.system/skill-installer/SKILL.md)
+> ### How to use skills
+> - Discovery: The list above is the skills available in this session (name + description + file path). Skill bodies live on disk at the listed paths.
+> - Trigger rules: If the user names a skill (with `$SkillName` or plain text) OR the task clearly matches a skill's description shown above, you must use that skill for that turn. Multiple mentions mean use them all. Do not carry skills across turns unless re-mentioned.
+> - Missing/blocked: If a named skill isn't in the list or the path can't be read, say so briefly and continue with the best fallback.
+> - How to use a skill (progressive disclosure):
+>   1) After deciding to use a skill, open its `SKILL.md`. Read only enough to follow the workflow.
+>   2) If `SKILL.md` points to extra folders such as `references/`, load only the specific files needed for the request; don't bulk-load everything.
+>   3) If `scripts/` exist, prefer running or patching them instead of retyping large code blocks.
+>   4) If `assets/` or templates exist, reuse them instead of recreating from scratch.
+> - Coordination and sequencing:
+>   - If multiple skills apply, choose the minimal set that covers the request and state the order you'll use them.
+>   - Announce which skill(s) you're using and why (one short line). If you skip an obvious skill, say why.
+> - Context hygiene:
+>   - Keep context small: summarize long sections instead of pasting them; only load extra files when needed.
+>   - Avoid deep reference-chasing: prefer opening only files directly linked from `SKILL.md` unless you're blocked.
+>   - When variants exist (frameworks, providers, domains), pick only the relevant reference file(s) and note that choice.
+> - Safety and fallback: If a skill can't be applied cleanly (missing files, unclear instructions), state the issue, pick the next-best approach, and continue.
+> </INSTRUCTIONS>
+>
+> <environment_context>
+>   <cwd>/Users/anicolao/projects/antigravity/food-fixups</cwd>
+>   <shell>zsh</shell>
+> </environment_context>
+>
+> read DEVELOPMENT.md and WORKFLOW.md and CODEX_REVIEW.md. Fix the race by making the reducer for upload complete update the state appropriately if the uplaod ends later. Mark it fixed in the markdown. Follow WORKFLOW.md to put this up as a PR. Put questions or open issues in the PR, don't pause to ask me things.
+
+## Relevant User Comments
+> Your main is not up to date which is why you're not finding CODEX_REVIEW; I have fetched it but you need to rebase against origin/main, fix any mrege conflicts, and put up the PR again.

--- a/docs/DESIGN_REVIEW.md
+++ b/docs/DESIGN_REVIEW.md
@@ -11,6 +11,7 @@ Audit the codebase to ensure that distinct user actions and external system inte
 - On "Save", `uploadImage` is called inside a `Promise.race` with a 3-second timeout.
 - **Data Loss Risk**: If the upload times out or fails (e.g., offline), the error is caught, `driveUrls` remains empty, and the entry is saved *without* the images.
 - **Observability Void**: There is no record that the user *attempted* to upload images. The `log/entryConfirmed` event simply appears as a text-only entry.
+- **Status**: Fixed by updating projections to attach `media/uploadCompleted` URLs to entries that reference the pending `tempId`.
 
 **Missing Events**:
 - `media/uploadStarted`: Capturing the intent to upload, including a temporary client-side ID.

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -247,6 +247,24 @@ const applyEventToState = (state: any, event: FoodEvent) => {
       }
       break;
     }
+    case 'media/uploadCompleted': {
+      const { tempId, url } = event.payload;
+      if (!tempId || !url) break;
+
+      state.log.forEach((entry: LogEntry) => {
+        if (!entry.mediaIds?.includes(tempId)) return;
+
+        const existingUrls = entry.imageDriveUrl
+          ? entry.imageDriveUrl.split(',').map((u) => u.trim()).filter(Boolean)
+          : [];
+
+        if (!existingUrls.includes(url)) {
+          existingUrls.push(url);
+          entry.imageDriveUrl = existingUrls.join(', ');
+        }
+      });
+      break;
+    }
   }
 };
 


### PR DESCRIPTION
# Fix: Upload Completion Race

## Changes
- Update projections to attach `media/uploadCompleted` URLs to entries that reference pending media IDs.
- Mark the upload race as fixed in `docs/DESIGN_REVIEW.md`.

## Testing
- Not run (not requested).

## Questions / Open Issues
- None.

## Original User Prompt(s)
> # AGENTS.md instructions for /Users/anicolao/projects/antigravity/food-fixups
>
> <INSTRUCTIONS>
> ## Skills
> A skill is a set of local instructions to follow that is stored in a `SKILL.md` file. Below is the list of skills that can be used. Each entry includes a name, description, and file path so you can open the source for full instructions when using a specific skill.
> ### Available skills
> - skill-creator: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Codex's capabilities with specialized knowledge, workflows, or tool integrations. (file: /Users/anicolao/.codex/skills/.system/skill-creator/SKILL.md)
> - skill-installer: Install Codex skills into $CODEX_HOME/skills from a curated list or a GitHub repo path. Use when a user asks to list installable skills, install a curated skill, or install a skill from another repo (including private repos). (file: /Users/anicolao/.codex/skills/.system/skill-installer/SKILL.md)
> ### How to use skills
> - Discovery: The list above is the skills available in this session (name + description + file path). Skill bodies live on disk at the listed paths.
> - Trigger rules: If the user names a skill (with `$SkillName` or plain text) OR the task clearly matches a skill's description shown above, you must use that skill for that turn. Multiple mentions mean use them all. Do not carry skills across turns unless re-mentioned.
> - Missing/blocked: If a named skill isn't in the list or the path can't be read, say so briefly and continue with the best fallback.
> - How to use a skill (progressive disclosure):
>   1) After deciding to use a skill, open its `SKILL.md`. Read only enough to follow the workflow.
>   2) If `SKILL.md` points to extra folders such as `references/`, load only the specific files needed for the request; don't bulk-load everything.
>   3) If `scripts/` exist, prefer running or patching them instead of retyping large code blocks.
>   4) If `assets/` or templates exist, reuse them instead of recreating from scratch.
> - Coordination and sequencing:
>   - If multiple skills apply, choose the minimal set that covers the request and state the order you'll use them.
>   - Announce which skill(s) you're using and why (one short line). If you skip an obvious skill, say why.
> - Context hygiene:
>   - Keep context small: summarize long sections instead of pasting them; only load extra files when needed.
>   - Avoid deep reference-chasing: prefer opening only files directly linked from `SKILL.md` unless you're blocked.
>   - When variants exist (frameworks, providers, domains), pick only the relevant reference file(s) and note that choice.
> - Safety and fallback: If a skill can't be applied cleanly (missing files, unclear instructions), state the issue, pick the next-best approach, and continue.
> </INSTRUCTIONS>
>
> <environment_context>
>   <cwd>/Users/anicolao/projects/antigravity/food-fixups</cwd>
>   <shell>zsh</shell>
> </environment_context>
>
> read DEVELOPMENT.md and WORKFLOW.md and CODEX_REVIEW.md. Fix the race by making the reducer for upload complete update the state appropriately if the uplaod ends later. Mark it fixed in the markdown. Follow WORKFLOW.md to put this up as a PR. Put questions or open issues in the PR, don't pause to ask me things.

## Relevant User Comments
> Your main is not up to date which is why you're not finding CODEX_REVIEW; I have fetched it but you need to rebase against origin/main, fix any mrege conflicts, and put up the PR again.