### PR TITLE
Namespace sync pointers by spreadsheet

### DIFF
--- a/CODEX_REVIEW.md
+++ b/CODEX_REVIEW.md
@@ -7,14 +7,14 @@
 
 ### Medium
 - Resolved: Removed the unused `FavouriteItem.id` field and stopped generating UUIDs in the reducer to keep event replays deterministic.
-- `src/lib/sync-manager.ts:57-127`: Sync pointers (`lastSyncedRow`, `lastSyncedEventId`) are stored globally in `localStorage` without namespacing by `spreadsheetId` or user. Switching accounts/spreadsheets can reuse stale pointers and skip or duplicate events until a reset. Store pointers per spreadsheet/user or reset them when config changes.
+- Resolved: Sync pointers are now namespaced by `spreadsheetId`, with a one-time migration from legacy global keys.
 
 ### Low
 - `src/lib/components/ui/NutrientInput.svelte:37-43`: Clearing an input sets `val` to `undefined`, but `onupdate` is skipped when `val` is `undefined`. This makes it impossible to clear a numeric field without it reverting to its previous value. Consider firing updates for empty values and letting the parent decide how to handle `undefined`/`null`.
 - `src/lib/images.ts:3-30`: `resolveDriveImage` caches `URL.createObjectURL` results indefinitely without revocation. Over long sessions this can leak memory. Consider evicting old entries and calling `URL.revokeObjectURL` when images are no longer needed.
 
 ## Questions / Assumptions
-- Do you expect users to sign into multiple Google accounts on the same device/browser? If yes, local sync pointers need to be scoped per account/spreadsheet.
+None.
 
 ## Notes
 - No automated tests were run for this review.

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -4,6 +4,7 @@
 - Namespace sync pointer keys by `spreadsheetId` and migrate legacy global keys on first use.
 - Update Codex review notes for the resolved sync-pointer issue.
 - Raise the log-page visibility checks to 2000ms to match the timeout cap.
+- Navigate to the log page via the dashboard button to avoid slow full reloads in CI.
 
 ## Testing
 - `.husky/pre-commit` (svelte-check warnings; Playwright: 13 passed, 1 skipped).

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -3,6 +3,7 @@
 ## Changes
 - Namespace sync pointer keys by `spreadsheetId` and migrate legacy global keys on first use.
 - Update Codex review notes for the resolved sync-pointer issue.
+- Raise the log-page visibility checks to 2000ms to match the timeout cap.
 
 ## Testing
 - `.husky/pre-commit` (svelte-check warnings; Playwright: 13 passed, 1 skipped).

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,12 +1,8 @@
-# Fix: Wait for Synced Status Before Screenshots
+# Fix: Namespace Sync Pointers
 
 ## Changes
-- Require a stable `data-status` value (default `synced`) before Playwright screenshots.
-- Allow tests to override expected network status (used for sync-error screenshots).
-- Wait for the nutrition details toggle icon to finish loading before taking screenshots.
-- Wait for the log page header/buttons to render before screenshot steps to avoid timing flake.
-- Refresh the detailed nutrition edit snapshot after syncing completes.
-- Set E2E timeout guidance to 2000ms max and forbid arbitrary waits.
+- Namespace sync pointer keys by `spreadsheetId` and migrate legacy global keys on first use.
+- Update Codex review notes for the resolved sync-pointer issue.
 
 ## Testing
 - `.husky/pre-commit` (svelte-check warnings; Playwright: 13 passed, 1 skipped).
@@ -15,15 +11,6 @@
 - None.
 
 ## Original User Prompt(s)
-> The e2e tests failed in CI. Use gh to download the logs and artifacts and resolve the failure.
->
-> for installing tools, you can use nix (edit flake.nix) and run them with nix develop -c
-> it isn't an error state in CI, CI isn't waiting for sync to complete before taking the screenshot and that is the problem/the correct fix
->
 > Ok I have rebased and merged the branch. go to main and pull and then resolve the next item from CODEX_REVIEW.md
 >
-> On your new branch with the e2e fix, CI is failing. Look at the run to determine waht the problem is and fix the PR.
->
-> You seem to not be able to look at the screenshot. In this case, teh problem is a missing + icon from the nutrient details form. The expected screenshot is correct. The acutal screenshot has been taken befor ethe + icon has loaded and is missing the icon. It's a new problem, unrelated to the fix on this branch, but nonetheless needs fixing.
->
-> all PRs should be based off of origin main and updated on github, so please fix it for easy review.
+> never bypass precommit. make a rule about that. Run the precommit checks now.

--- a/src/lib/sync-manager.ts
+++ b/src/lib/sync-manager.ts
@@ -55,9 +55,7 @@ export const syncManager = {
             const { spreadsheetId } = state.config;
 
             if (spreadsheetId) {
-                // Get last synced row index (default to 0 if no headers involved in tracking)
-                const lastSyncedRow = parseInt(localStorage.getItem('lastSyncedRow') || '0', 10);
-                const lastSyncedEventId = localStorage.getItem('lastSyncedEventId') || '';
+                const { lastSyncedRow, lastSyncedEventId } = getSyncPointers(spreadsheetId);
 
                 // If we have synced data (row > 0), we fetch overlapping to verify.
                 // If row is 0, we fetch from 1.
@@ -77,8 +75,7 @@ export const syncManager = {
                         // If lastSyncedEventId exists (for safety), verify it matches
                         if (lastSyncedEventId && overlappingEventId !== lastSyncedEventId) {
                             console.warn(`[SyncManager] Sync Mismatch! Expected ${lastSyncedEventId}, got ${overlappingEventId}. Resetting sync pointer.`);
-                            localStorage.setItem('lastSyncedRow', '0');
-                            localStorage.removeItem('lastSyncedEventId');
+                            clearSyncPointers(spreadsheetId);
                             return; // Next sync will start from 1
                         }
 
@@ -121,10 +118,7 @@ export const syncManager = {
                         // Update Pointer
                         const finalRowIndex = lastSyncedRow + newRows.length;
 
-                        localStorage.setItem('lastSyncedRow', finalRowIndex.toString());
-                        if (lastEventIdProcessed) {
-                            localStorage.setItem('lastSyncedEventId', lastEventIdProcessed);
-                        }
+                        setSyncPointers(spreadsheetId, finalRowIndex, lastEventIdProcessed);
 
                     } else {
 
@@ -134,8 +128,7 @@ export const syncManager = {
                     // If lastSyncedRow > 0, we expected at least overlap.
                     if (lastSyncedRow > 0) {
                         console.warn('[SyncManager] Last synced row missing. Sheet truncated? Resetting.');
-                        localStorage.setItem('lastSyncedRow', '0');
-                        localStorage.removeItem('lastSyncedEventId');
+                        clearSyncPointers(spreadsheetId);
                     }
                 }
             }
@@ -155,8 +148,10 @@ export const syncManager = {
 
                 if (errObj.status === 400) {
                     console.warn('[SyncManager] 400 Error on fetch. Pointer invalid. Resetting.');
-                    localStorage.setItem('lastSyncedRow', '0');
-                    localStorage.removeItem('lastSyncedEventId');
+                    const { spreadsheetId } = store.getState().config;
+                    if (spreadsheetId) {
+                        clearSyncPointers(spreadsheetId);
+                    }
                     // We successfully handled it by resetting, so maybe don't show user error?
                     // Actually, let's show it so they know *why* it might re-sync next time or if it persists.
                     // But if we reset, the next sync (poll) might succeed.
@@ -184,8 +179,12 @@ export const syncManager = {
         this.syncError = null;
 
         // 1. Reset Pointer
-        localStorage.setItem('lastSyncedRow', '0');
-        localStorage.removeItem('lastSyncedEventId');
+        const { spreadsheetId } = store.getState().config;
+        if (spreadsheetId) {
+            clearSyncPointers(spreadsheetId);
+        } else {
+            clearLegacySyncPointers();
+        }
 
         // 2. Clear Local Cache (Synced Items Only - preserve pending!)
         await clearAllSyncedEvents();
@@ -197,4 +196,56 @@ export const syncManager = {
     }
 };
 
+const SYNC_POINTER_PREFIX = 'syncPointer';
+const LEGACY_ROW_KEY = 'lastSyncedRow';
+const LEGACY_EVENT_KEY = 'lastSyncedEventId';
 
+const getScopedKey = (spreadsheetId: string, key: string) =>
+    `${SYNC_POINTER_PREFIX}:${spreadsheetId}:${key}`;
+
+const getSyncPointers = (spreadsheetId: string) => {
+    const rowKey = getScopedKey(spreadsheetId, 'row');
+    const eventKey = getScopedKey(spreadsheetId, 'eventId');
+
+    const storedRow = localStorage.getItem(rowKey);
+    const storedEventId = localStorage.getItem(eventKey);
+
+    if (storedRow !== null || storedEventId !== null) {
+        return {
+            lastSyncedRow: parseInt(storedRow || '0', 10),
+            lastSyncedEventId: storedEventId || ''
+        };
+    }
+
+    const legacyRow = localStorage.getItem(LEGACY_ROW_KEY);
+    const legacyEventId = localStorage.getItem(LEGACY_EVENT_KEY);
+
+    if (legacyRow !== null || legacyEventId !== null) {
+        const lastSyncedRow = parseInt(legacyRow || '0', 10);
+        const lastSyncedEventId = legacyEventId || '';
+        setSyncPointers(spreadsheetId, lastSyncedRow, lastSyncedEventId);
+        clearLegacySyncPointers();
+        return { lastSyncedRow, lastSyncedEventId };
+    }
+
+    return { lastSyncedRow: 0, lastSyncedEventId: '' };
+};
+
+const setSyncPointers = (spreadsheetId: string, row: number, eventId: string) => {
+    localStorage.setItem(getScopedKey(spreadsheetId, 'row'), row.toString());
+    if (eventId) {
+        localStorage.setItem(getScopedKey(spreadsheetId, 'eventId'), eventId);
+    } else {
+        localStorage.removeItem(getScopedKey(spreadsheetId, 'eventId'));
+    }
+};
+
+const clearSyncPointers = (spreadsheetId: string) => {
+    localStorage.setItem(getScopedKey(spreadsheetId, 'row'), '0');
+    localStorage.removeItem(getScopedKey(spreadsheetId, 'eventId'));
+};
+
+const clearLegacySyncPointers = () => {
+    localStorage.setItem(LEGACY_ROW_KEY, '0');
+    localStorage.removeItem(LEGACY_EVENT_KEY);
+};

--- a/tests/e2e/002-log-food/002-log-food.spec.ts
+++ b/tests/e2e/002-log-food/002-log-food.spec.ts
@@ -101,8 +101,6 @@ test('US-003 to US-010: User logs food flow', async ({ page }, testInfo) => {
     await page.goto('/');
     // Allow polling to initialize tokenClient
     await page.waitForFunction(() => (window as any)._authReady);
-    // Explicit wait for hydration/interactivity
-    await page.waitForTimeout(1000);
     const signInBtn = page.getByText('Sign In with Google');
     await expect(signInBtn).toBeVisible();
     await signInBtn.click();
@@ -113,11 +111,13 @@ test('US-003 to US-010: User logs food flow', async ({ page }, testInfo) => {
     const logBtn = page.getByLabel('Log new food entry').first();
     await expect(logBtn).toBeVisible();
     await expect(logBtn).toBeEnabled();
-    const isVisible = await logBtn.isVisible();
 
     // Fallback if click fails silently: force click
     // await logBtn.click({ force: true });
-    await page.goto('/log');
+    await Promise.all([
+        page.waitForURL(/\/log/, { timeout: 2000 }),
+        logBtn.click()
+    ]);
 
     // Mandatory URL Wait for stability
     await expect(page).toHaveURL(/\/log/);

--- a/tests/e2e/002-log-food/002-log-food.spec.ts
+++ b/tests/e2e/002-log-food/002-log-food.spec.ts
@@ -122,15 +122,15 @@ test('US-003 to US-010: User logs food flow', async ({ page }, testInfo) => {
     // Mandatory URL Wait for stability
     await expect(page).toHaveURL(/\/log/);
     await page.waitForLoadState('domcontentloaded');
-    await expect(page.getByRole('heading', { name: 'Log Food' })).toBeVisible({ timeout: 1000 });
+    await expect(page.getByRole('heading', { name: 'Log Food' })).toBeVisible({ timeout: 2000 });
 
     await tester.step('log-page', {
         description: 'User on log page',
         verifications: [
-            { spec: 'Camera button visible', check: async () => await expect(page.getByText('Camera').first()).toBeVisible({ timeout: 1000 }) },
-            { spec: 'Upload button visible', check: async () => await expect(page.getByText('Library').first()).toBeVisible({ timeout: 1000 }) },
-            { spec: 'Voice button visible', check: async () => await expect(page.getByText('Voice').first()).toBeVisible({ timeout: 1000 }) },
-            { spec: 'Text button visible', check: async () => await expect(page.getByText('Text').first()).toBeVisible({ timeout: 1000 }) }
+            { spec: 'Camera button visible', check: async () => await expect(page.getByText('Camera').first()).toBeVisible({ timeout: 2000 }) },
+            { spec: 'Upload button visible', check: async () => await expect(page.getByText('Library').first()).toBeVisible({ timeout: 2000 }) },
+            { spec: 'Voice button visible', check: async () => await expect(page.getByText('Voice').first()).toBeVisible({ timeout: 2000 }) },
+            { spec: 'Text button visible', check: async () => await expect(page.getByText('Text').first()).toBeVisible({ timeout: 2000 }) }
         ]
     });
 


### PR DESCRIPTION
# Fix: Namespace Sync Pointers

## Changes
- Namespace sync pointer keys by `spreadsheetId` and migrate legacy global keys on first use.
- Update Codex review notes for the resolved sync-pointer issue.
- Raise the log-page visibility checks to 2000ms to match the timeout cap.
- Navigate to the log page via the dashboard button to avoid slow full reloads in CI.

## Testing
- `.husky/pre-commit` (svelte-check warnings; Playwright: 13 passed, 1 skipped).

## Questions / Open Issues
- None.

## Original User Prompt(s)
> Ok I have rebased and merged the branch. go to main and pull and then resolve the next item from CODEX_REVIEW.md
>
> never bypass precommit. make a rule about that. Run the precommit checks now.
