### PR TITLE
fix(e2e): decouple click and navigation wait

### DIFF
--- a/tests/e2e/002-log-food/002-log-food.spec.ts
+++ b/tests/e2e/002-log-food/002-log-food.spec.ts
@@ -112,15 +112,10 @@ test('US-003 to US-010: User logs food flow', async ({ page }, testInfo) => {
     await expect(logBtn).toBeVisible();
     await expect(logBtn).toBeEnabled();
 
-    // Fallback if click fails silently: force click
-    // await logBtn.click({ force: true });
-    await Promise.all([
-        page.waitForURL(/\/log/, { timeout: 2000 }),
-        logBtn.click()
-    ]);
+    await logBtn.click();
+    await expect(page).toHaveURL(/\/log/, { timeout: 2000 });
 
     // Mandatory URL Wait for stability
-    await expect(page).toHaveURL(/\/log/);
     await page.waitForLoadState('domcontentloaded');
     await expect(page.getByRole('heading', { name: 'Log Food' })).toBeVisible({ timeout: 2000 });
 


### PR DESCRIPTION
Fixes flaky E2E test by decoupling the strict 2000ms navigation timeout from the potentially slow click interaction in CI.