### PR TITLE
Fix: AI representative images overriding manual corrections

### DIFF
--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -49,6 +49,7 @@
     file: File;
     previewUrl: string;
     uploadPromise: Promise<GoogleDriveFile | null>;
+    isRepresentative?: boolean;
   };
 
   let attachedMedia: AttachedMedia[] = $state([]);
@@ -287,6 +288,7 @@
     file: File,
     triggerAnalysis: boolean = true,
     skipExif: boolean = false,
+    isRepresentative: boolean = false,
   ) {
     if (!skipExif) {
       try {
@@ -378,6 +380,7 @@
             file,
             previewUrl,
             uploadPromise,
+            isRepresentative,
           },
         ];
 
@@ -393,7 +396,11 @@
   }
 
   async function runAnalysis(correction?: string) {
-    if (imagePreviews.length === 0) return;
+    // Only send non-representative images to Gemini for analysis
+    const realMedia = attachedMedia.filter((m) => !m.isRepresentative);
+    
+    // We allow analysis if we have real images OR if it's a correction/text analysis
+    if (realMedia.length === 0 && !correction && currentMode !== "TEXT" && currentMode !== "VOICE") return;
 
     analyzing = true;
     const requestId = crypto.randomUUID();
@@ -405,13 +412,13 @@
       store.dispatch(
         dispatchEvent("ai/analysisRequested", {
           requestId,
-          inputType: "image",
-          contentLength: attachedMedia.length,
-          mediaIds: attachedMedia.map((m) => m.tempId),
+          inputType: realMedia.length > 0 ? "image" : "text",
+          contentLength: realMedia.length > 0 ? realMedia.length : correction?.length || 0,
+          mediaIds: realMedia.map((m) => m.tempId),
         }),
       );
 
-      const images = attachedMedia.map((media, i) => {
+      const images = realMedia.map((media, i) => {
         try {
           return {
             base64: media.previewUrl.split(",")[1],
@@ -454,7 +461,7 @@
       store.dispatch(
         dispatchEvent("log/aiEstimateReceived", {
           requestId, // tracing
-          imagesCount: attachedMedia.length,
+          imagesCount: realMedia.length,
           rawJson: result,
         }),
       );
@@ -521,7 +528,8 @@
             );
             // PASS FALSE to skip re-analysis!
             // PASS TRUE to skip EXIF (use current time for search/generated images)
-            await addImage(file, false, true);
+            // PASS TRUE to mark as representative (prevent sending back to Gemini)
+            await addImage(file, false, true, true);
           } else {
             // Only fallback if it's NOT a 404 (e.g. 403 or opaque might be loadable via img tag)
             console.warn("Failed to fetch matched image, using direct URL");

--- a/tests/e2e/078-fix-ai-correction-image.spec.ts
+++ b/tests/e2e/078-fix-ai-correction-image.spec.ts
@@ -1,0 +1,207 @@
+
+import { test, expect } from './fixtures';
+import { mockDriveAPI } from './helpers/mock-drive';
+
+test.describe('Issue #78: AI Correction Image Bug', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept Gemini requests
+    await page.route('**/v1beta/models/gemini-*:generateContent*', async (route) => {
+      await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+              candidates: [{
+                  content: {
+                      parts: [{
+                          text: JSON.stringify({
+                              item_name: 'Mock Food',
+                              calories: 100,
+                              protein: 10,
+                              fat: { total: 5 },
+                              carbohydrates: { total: 10 },
+                              rationale: 'Mock rationale',
+                              searchQuery: 'Chocolate Swiss roll'
+                          })
+                      }]
+                  }
+              }]
+          })
+      });
+    });
+
+    // Mock Google Auth
+    await page.addInitScript(() => {
+      (window as any).google = {
+          accounts: {
+              oauth2: {
+                  initTokenClient: (c: any) => ({ requestAccessToken: () => c.callback({ access_token: 'mock-token' }) }),
+                  revoke: (token: string, cb: any) => cb()
+              }
+          }
+      };
+    });
+
+    // Block real Google Identity script
+    await page.route('https://accounts.google.com/gsi/client', route => route.abort());
+    
+    // Use generic Drive/Sheets mocks
+    await mockDriveAPI(page);
+
+    // Mock image search
+    await page.route('**/search-image*', async (route) => {
+      await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ imageUrl: 'https://example.com/food.jpg' })
+      });
+    });
+
+    // Mock the image fetch
+    await page.route('https://example.com/food.jpg', async (route) => {
+      await route.fulfill({
+          status: 200,
+          contentType: 'image/jpeg',
+          body: Buffer.from('fake-representative-image')
+      });
+    });
+  });
+
+  async function login(page: any) {
+    await page.goto('/');
+    await page.waitForFunction(() => (window as any)._authReady);
+    await page.click('button:has-text("Sign In with Google")');
+    await page.goto('/log');
+  }
+
+  test('representative images are NOT sent in correction requests', async ({ page }) => {
+    await login(page);
+    
+    // 1. Trigger text analysis to get a representative image
+    await page.click('button:has-text("Text")');
+    await page.fill('textarea', 'Chocolate Swiss roll');
+    await page.click('button:has-text("Analyze")');
+    await page.waitForSelector('.analyzing-state', { state: 'hidden' });
+
+    // 2. Intercept re-analysis
+    let reanalysisData: any = null;
+    await page.route('**/v1beta/models/gemini-*:generateContent*', async (route) => {
+      reanalysisData = route.request().postDataJSON();
+      await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+              candidates: [{
+                  content: {
+                      parts: [{
+                          text: JSON.stringify({
+                              item_name: 'Corrected Food',
+                              calories: 50,
+                              protein: 5,
+                              fat: { total: 2 },
+                              carbohydrates: { total: 5 },
+                              rationale: 'Corrected'
+                          })
+                      }]
+                  }
+              }]
+          })
+      });
+    });
+
+    // 3. Correct AI
+    await page.click('button:has-text("Correct AI")');
+    await page.fill('textarea[placeholder*="e.g."]', 'Actually it was half');
+    await page.click('button:has-text("Retry")');
+    await page.waitForSelector('.analyzing-state', { state: 'hidden' });
+
+    expect(reanalysisData).toBeDefined();
+    const hasImage = reanalysisData.contents[0].parts.some((p: any) => p.inlineData);
+    expect(hasImage).toBe(false);
+  });
+
+  test('real images ARE still sent in correction requests', async ({ page }) => {
+    await login(page);
+    
+    // 1. Attach a REAL image
+    const buffer = Buffer.from('fake-real-image');
+    await page.setInputFiles('input[type="file"]', {
+      name: 'real-food.jpg',
+      mimeType: 'image/jpeg',
+      buffer: buffer
+    });
+    await page.waitForSelector('.analyzing-state', { state: 'hidden' });
+
+    // 2. Intercept re-analysis
+    let reanalysisData: any = null;
+    await page.route('**/v1beta/models/gemini-*:generateContent*', async (route) => {
+      reanalysisData = route.request().postDataJSON();
+      await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+              candidates: [{
+                  content: {
+                      parts: [{
+                          text: JSON.stringify({
+                              item_name: 'Corrected Food',
+                              calories: 50,
+                              protein: 5,
+                              fat: { total: 2 },
+                              carbohydrates: { total: 5 },
+                              rationale: 'Corrected'
+                          })
+                      }]
+                  }
+              }]
+          })
+      });
+    });
+
+    // 3. Correct AI
+    await page.click('button:has-text("Correct AI")');
+    await page.fill('textarea[placeholder*="e.g."]', 'It was 2 eggs');
+    await page.click('button:has-text("Retry")');
+    await page.waitForSelector('.analyzing-state', { state: 'hidden' });
+
+    expect(reanalysisData).toBeDefined();
+    const hasImage = reanalysisData.contents[0].parts.some((p: any) => p.inlineData);
+    expect(hasImage).toBe(true);
+  });
+
+  test('mixed media: only real images are sent in correction requests', async ({ page }) => {
+    await login(page);
+    
+    // 1. Get representative image
+    await page.click('button:has-text("Text")');
+    await page.fill('textarea', 'Chocolate Swiss roll');
+    await page.click('button:has-text("Analyze")');
+    await page.waitForSelector('.analyzing-state', { state: 'hidden' });
+
+    // 2. Attach a REAL image
+    const buffer = Buffer.from('fake-real-image');
+    await page.setInputFiles('input[type="file"]', {
+      name: 'real-food.jpg',
+      mimeType: 'image/jpeg',
+      buffer: buffer
+    });
+    await page.waitForSelector('.analyzing-state', { state: 'hidden' });
+
+    // 3. Intercept re-analysis
+    let reanalysisData: any = null;
+    await page.route('**/v1beta/models/gemini-*:generateContent*', async (route) => {
+      reanalysisData = route.request().postDataJSON();
+      await route.continue();
+    });
+
+    // 4. Correct AI
+    await page.click('button:has-text("Correct AI")');
+    await page.fill('textarea[placeholder*="e.g."]', 'Correcting');
+    await page.click('button:has-text("Retry")');
+    await page.waitForSelector('.analyzing-state', { state: 'hidden' });
+
+    expect(reanalysisData).toBeDefined();
+    const images = reanalysisData.contents[0].parts.filter((p: any) => p.inlineData);
+    expect(images.length).toBe(1);
+    expect(images[0].inlineData.data).toBe(buffer.toString('base64'));
+  });
+});


### PR DESCRIPTION
Issue #78: When using text input, the AI sometimes fetches a representative image. If the user then tries to 'Correct AI,' the system was feeding that generated image back into the prompt, potentially overriding manual corrections.

This PR fixes this by:
- Tagging fetched representative images.
- Filtering out representative images during AI re-analysis.
- Allowing re-analysis to proceed with text-only corrections when no real photos are present.

Verified with new E2E test suite: tests/e2e/078-fix-ai-correction-image.spec.ts