### PR TITLE
Fix production version display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "temp-app",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "temp-app",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@reduxjs/toolkit": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "temp-app",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 5174 --strictPort",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,8 +29,8 @@ export default defineConfig({
 	plugins: [sveltekit()],
 	define: {
 		'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version),
-		'import.meta.env.VITE_APP_COMMIT_HASH': JSON.stringify(process.env.CI ? 'deadbee' : getGitHash()),
-		'import.meta.env.VITE_APP_BUILD_DATE': JSON.stringify(process.env.CI ? '2026-01-01T00:00:00.000Z' : new Date().toISOString()),
+		'import.meta.env.VITE_APP_COMMIT_HASH': JSON.stringify(getGitHash()),
+		'import.meta.env.VITE_APP_BUILD_DATE': JSON.stringify(new Date().toISOString()),
 		'import.meta.env.VITE_APP_DIRTY_FLAG': JSON.stringify(process.env.CI ? false : getGitDirty())
 	}
 });


### PR DESCRIPTION
This PR fixes the issue where the production version display was showing incorrect information.

### Changes:
- Updated `vite.config.ts` to always use the real git hash and current build date, even in CI environments.
- Bumped `version` in `package.json` to `0.1.0`.
- Updated `package-lock.json`.

Verified that the production build output correctly contains the version, real commit hash, and recent timestamp.

Closes #104