### PR TITLE
fix: fix deployment workflow and update documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -35,7 +39,7 @@ jobs:
             echo "dir=pr${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
           else
             echo "path=/food" >> $GITHUB_OUTPUT
-            echo "dir=." >> $GITHUB_OUTPUT
+            echo "dir=" >> $GITHUB_OUTPUT
           fi
 
       - name: Build
@@ -57,7 +61,17 @@ jobs:
             echo "✅ OAuth configuration is present"
           fi
 
-      - name: Deploy to gh-pages branch
+      - name: Deploy to gh-pages (Production)
+        if: github.event_name != 'pull_request'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          # destination_dir is intentionally NOT set for production to deploy to root
+          keep_files: true
+
+      - name: Deploy to gh-pages (PR Preview)
+        if: github.event_name == 'pull_request'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,3 +46,21 @@ We assume that if a feature is not tested, it is broken.
 -   **GitHub Workflows**: Every PR is validated by the E2E suite.
 -   **PR Previews**: Deployments are generated for every PR to allow manual verification.
 -   **User Stories**: Every user story must be accompanied by at least one E2E test case.
+
+## Deployment
+
+The application is automatically deployed to GitHub Pages.
+
+-   **Production**: Merges to the `main` branch are deployed to the root of the site.
+-   **PR Previews**: Pull requests are deployed to a subdirectory named `pr<number>`.
+
+### Manual Trigger
+If an automatic deployment is not triggered (e.g., when a PR is merged by an autonomous agent using the default `GITHUB_TOKEN`), you can manually trigger the deployment:
+
+```bash
+gh workflow run deploy.yml --ref main
+```
+
+### Known Limitations
+GitHub does not trigger workflows from events (like merges) performed by the default `GITHUB_TOKEN`. In such cases, manual triggering or using a Personal Access Token (PAT) is required.
+


### PR DESCRIPTION
This PR fixes the deployment workflow to ensure it works correctly when merging to the main branch. It also adds a section to DEVELOPMENT.md explaining the deployment process and how to manually trigger it.

Key Changes:
- Added concurrency to .github/workflows/deploy.yml to prevent race conditions.
- Split deployment into Production and PR Preview steps.
- Fixed Production deployment to correctly target the root of the gh-pages branch.
- Updated DEVELOPMENT.md with deployment details and manual trigger instructions.

Closes #123